### PR TITLE
Fix snapshot space configuration validation 

### DIFF
--- a/packages/app/src/services/snapshot.ts
+++ b/packages/app/src/services/snapshot.ts
@@ -13,7 +13,11 @@ export const getSnapshotSpaceSettings = async (ensName: string, chainId: number)
   const res = await fetch(`${getHubUrl(chainId)}/api/spaces/${ensName}`)
   if (res.ok) {
     try {
-      return await res.json()
+      return await res.json().then((res) => {
+        // Remove flagged, verified, hibernated, and turbo properties from res, as they are not part of the space config, but rater extra info from the server.
+        const { flagged, verified, hibernated, turbo, ...filteredRes } = res
+        return filteredRes
+      })
     } catch (error) {
       return undefined // there is not snapshot space for this ENS
     }

--- a/packages/backend/lib/snapshot.ts
+++ b/packages/backend/lib/snapshot.ts
@@ -14,7 +14,11 @@ export const getSnapshotSpaceSettings = async (ensName: string, chainId: number)
   const res = await fetch(`${getHubUrl(chainId)}/api/spaces/${ensName}`)
   if (res.ok) {
     try {
-      return await res.json()
+      return await res.json().then((res) => {
+        // Remove flagged, verified, hibernated, and turbo properties from res, as they are not part of the space config, but rater extra info from the server.
+        const { flagged, verified, hibernated, turbo, ...filteredRes } = res
+        return filteredRes
+      })
     } catch (error) {
       return undefined // there is not snapshot space for this ENS
     }


### PR DESCRIPTION
The Snapshot Hub has started to return some fields inside of the snapshot space configuration that are not really part of the space configuration. This will remove those extra attributes after retrieving the space configuration. The actual space config should not include them, and it makes the space config validation fail (as it should). 
