### PR TITLE
fix: governor mod token validation

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodiac-app",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "homepage": "./",
   "type": "module",

--- a/packages/app/src/views/AddModule/wizards/OzGovernor/service/tokenValidation.ts
+++ b/packages/app/src/views/AddModule/wizards/OzGovernor/service/tokenValidation.ts
@@ -20,10 +20,9 @@ export const isVotesCompilable = (provider: BrowserProvider) => async (tokenAddr
       tokenContract.getVotes(RANDOM_VALID_ADDRESS),
       tokenContract.getPastVotes(RANDOM_VALID_ADDRESS, RANDOM_BLOCK_NUMBER),
       tokenContract.getPastTotalSupply(RANDOM_BLOCK_NUMBER),
-      tokenContract.delegates(RANDOM_VALID_ADDRESS),
+      tokenContract.delegates.staticCall(RANDOM_VALID_ADDRESS),
     ])
-    // @ts-ignore
-    tokenContract.functions['delegateBySig'].name
+    tokenContract.delegateBySig.name
   } catch (e) {
     console.log(e)
     return false


### PR DESCRIPTION
## Bug Report
https://discord.com/channels/881881751369175040/1032974561735606322/1268312094386950286

## Implementation

In the `packages/app/src/views/AddModule/wizards/OzGovernor/service/tokenValidation.ts` file, the following changes were made to fix the bug:

1. Replaced `tokenContract.delegates(RANDOM_VALID_ADDRESS)` with `tokenContract.delegates.staticCall(RANDOM_VALID_ADDRESS)`.
2. Removed the lines:
   ```typescript
   // @ts-ignore
   tokenContract.functions['delegateBySig'].name
   ```
3. Added the line:
   ```typescript
   tokenContract.delegateBySig.name
   ```

These changes ensure the application correctly identifies and calls the `delegateBySig` function on the contract, addressing the issues caused by the proxy contract used by the Arbitrum Foundation.

### Additional Context

The error reported was:
```
Error: missing revert data (action="call", data=null, reason=null, transaction={ "data": "0x9ab24eb0000000000000000000000000d028d504316fec029cfa36bdc3a8f053f6e5a6e4", "to": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8" }, invocation=null, revert=null, code=CALL_EXCEPTION, version=6.13.1)
    at makeError (errors.ts:694:21)
    at getBuiltinCallException (abi-coder.ts:118:12)
    at _AbiCoder.getBuiltinCallException (abi-coder.ts:235:16)
    at BrowserProvider.getRpcError (provider-jsonrpc.ts:989:32)
    at BrowserProvider.getRpcError (provider-browser.ts:122:22)
    at provider-jsonrpc.ts:563:45
```

This error occurred while testing with the Arbitrum Foundation's address `0x912CE59144191C1204E64559FE8253a0e49E6548`. The application was not seeing the `delegateBySig()` function on the contract, likely due to the proxy contract being used.

---

### Commit Changes

This change ensures that the function calls are correctly handled and improves compatibility with contracts deployed on all networks, specifically addressing the issues with proxy contracts.
