### PR TITLE
fix: name clash with ethers built-in

### DIFF
--- a/packages/app/src/views/ModuleDetails/contract/ContractFunctionQueryBlock.tsx
+++ b/packages/app/src/views/ModuleDetails/contract/ContractFunctionQueryBlock.tsx
@@ -62,7 +62,7 @@ export const ContractFunctionQueryBlock = ({ address, func }: ContractFunctionBl
   const execQuery = useCallback(
     (params?: any[]) => {
       setLastQueryDate(undefined)
-      fetch(provider, safe.chainId, address, [func], func.name, params)
+      fetch(provider, safe.chainId, address, [func], func.format(), params)
     },
     [address, fetch, func, safe.chainId, provider],
   )

--- a/packages/app/src/views/ModuleDetails/contract/ContractReadFunctionsList.tsx
+++ b/packages/app/src/views/ModuleDetails/contract/ContractReadFunctionsList.tsx
@@ -18,10 +18,10 @@ export const ContractReadFunctionsList = ({ abi, address, preview }: ModuleListF
     <>
       {readFunctions.map((func) => {
         if (preview) {
-          return <ContractFunctionPreviewBlock key={func.name} func={func} />
+          return <ContractFunctionPreviewBlock key={func.selector} func={func} />
         }
 
-        return <ContractFunctionQueryBlock key={func.name} address={address} func={func} />
+        return <ContractFunctionQueryBlock key={func.selector} address={address} func={func} />
       })}
     </>
   )


### PR DESCRIPTION
There's a bug causing the `target` field of any zodiac mod in the "Read contract" tab to display that mod's address rather than the value actually configured on the mod.

The bug was introduced through the ethers v6 upgrade as the ethers `Contract` class now has a built-in `target` property.

This PR fixes it by using the entire function signature, rather than just the name (which would have also failed with overloaded contract functions).