### PR TITLE
chore: update deprecated transaction endpoint to multisig-transactions

### DIFF
--- a/packages/app/src/services/index.ts
+++ b/packages/app/src/services/index.ts
@@ -520,7 +520,10 @@ export async function fetchSafeTransactions(
   const network = getNetworkExplorerInfo(chainId)
   if (!network) return []
 
-  const url = new URL(`api/v1/safes/${safeAddress}/transactions`, network.safeTransactionApi)
+  const url = new URL(
+    `api/v1/safes/${safeAddress}/multisig-transactions`,
+    network.safeTransactionApi,
+  )
 
   Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value))
 


### PR DESCRIPTION
## **Description:**  
Closes #246.  

This PR updates the Safe transactions API endpoint in `fetchSafeTransactions`. The previously used endpoint `/api/v1/safes/{safeAddress}/transactions` has been deprecated and is no longer available. Attempting to use it results in a 404 error, breaking the Zodiac Safe App functionality.

To ensure compatibility with the Safe Transaction Service, this fix updates the request to use the correct endpoint:  
✅ **New endpoint:** `/api/v1/safes/{safeAddress}/multisig-transactions/`  
This endpoint specifically returns multisig transactions associated with the given Safe address.

## **Bug Report:**  
- **Issue:** [[#246](https://github.com/gnosisguild/zodiac-safe-app/issues/246)](https://github.com/gnosisguild/zodiac-safe-app/issues/246)  
- **Affected Networks:** Optimism, Ethereum Sepolia Testnet (potentially others)  
- **Error Details:**  
  - The application was making GET requests to:
    ```
    https://safe-transaction-optimism.safe.global/api/v1/safes/{safeAddress}/transactions?nonce__gte={nonce}
    ```
  - This endpoint does not exist, leading to an HTTP 404 response.
  - As a result, critical functionality (e.g., adding roles to the Roles Modifier) was broken.

## **Implementation Details:**  
- The function `fetchSafeTransactions` now requests transactions from the correct API endpoint:
  ```ts
  const url = new URL(
    `api/v1/safes/${safeAddress}/multisig-transactions/`,
    network.safeTransactionApi
  );
  ```
- **Query parameters remain unchanged**, ensuring filters like `nonce__gte` continue to work as expected.
- The response structure remains compatible with existing logic.

## **Alternative Considerations:**  
- The Safe Transaction Service also provides `/api/v1/safes/{safeAddress}/all-transactions/`, which includes all transaction types (multisig, module, and incoming transactions). However, since the original implementation was fetching multisig transactions only, the fix remains consistent with that behavior.

## **References:**  
- Safe API Documentation: [Safe Core API - Transactions](https://docs.safe.global/core-api/transaction-service-reference/mainnet#Transactions)
